### PR TITLE
parses config and applies filter when creating map rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,8 @@ See `https://github.com/bsubei/squad_map_layers` for an example file (that will 
 # Running automatically in Crontab
 See the `crontab.example` for an example on what to add to the crontab to run this script automatically.
 
+# Running unit tests
+You can run the unit tests with `python3 -m pytest` in the project root directory (add `-s` to enable `ipdb` support).
+
 # License
 The license is GPLv3. See LICENSE file.

--- a/README.md
+++ b/README.md
@@ -1,34 +1,70 @@
-# Summary
-A script that generates a random map rotation for Squad using a certain pattern. Takes in all the available layers and generates an output `MapRotation.cfg` to be used by your Squad server (needs a restart, see crontab/schtasks to automate this). Optionally sends a Discord message with the map rotation (using a webhook).
+## Summary
+`squad_map_randomizer` is a script that generates random map rotations for Squad based on filters that you define in a config file.
 
-# Pattern
-    2x Random Skirmish Layers
-    Repeat the pattern 5x {
-        1x AAS or RAAS layer
-        1x AAS or RAAS layer that must have Helicopters
-        1x Invasion layer
-        1x AAS or RAAS layer
-    }
-    
-    Layers cannot be repeated in the entire rotation (without replacement policy when sampling).
-    A layer cannot be repeated if another layer of the same map was last played three (adjustable) maps ago.  
+Optional feature: posts a message containing the generated map rotation to a single Discord channel (requires Discord admin privileges).
 
+## Config File
+A map rotation is a sequence of maps consisting of starting maps followed by regular maps. You can specify the number of maps and the kinds of maps by using a config file, which uses a simple YAML format.
 
-# Installation
-You will need Python 3.6+ installed. Then install required dependencies using `pip3 install -r requirements.txt`. In order to use the `--discord-webhook-url` argument, you need to add a webhook to one of your Discord channels and use the webhook URL for the argument.
+The config file specifies:
+1. How many maps are in the map rotation.
+2. What filters to use for deciding the maps.
 
-# Usage
-Run `python3 squad_map_randomizer.py --help` for usage.
+### Example Config
+For example, the following config describes a map rotation with one Skirmish starting map, and six regular maps that alternate between small, medium, and large in size (notice we only define three regular maps and specify to repeat them twice):
 
-# JSON input file
-The script requires a JSON input file with all the map layer info in a particular format. 
-See `https://github.com/bsubei/squad_map_layers` for an example file (that will hopefully stay updated).
+> starting\_maps:
+>   - gamemode: Skirmish
+> number\_of\_repeats: 2
+> regular\_maps:
+>   - map\_size: small
+>   - map\_size: medium
+>   - map\_size: large
 
-# Running automatically in Crontab
-See the `crontab.example` for an example on what to add to the crontab to run this script automatically.
+Every time the script is run with this config, it will generate a map rotation with randomly chosen maps that follow the specified pattern, like this: skirmish map, small map, medium map, large map, small map, medium map, large map.
 
-# Running unit tests
+See the `configs/examples/` folder for more examples.
+
+### Config Details
+As seen in the example above, the config file has three top-level fields:
+
+1. An optional `starting_maps` field to specify the filters used to generate the starting maps. Defaults to empty if unspecified. Not affected by `number_of_repeats`.
+2. An optional `number_of_repeats` field to define how many times the rotation should repeat the `regular_maps` field. Defaults to 1 if unspecified.
+3. A required `regular_maps` field to define the filters for the map rotation (repeated `number_of_repeats` times).
+
+### Global Filters and Rules
+Besides the filters defined in the config, the following rules are applied globally for all map choices:
+
+1. A specific map cannot be repeated in the entire rotation (a without-replacement policy is used when randomly sampling). For example, if `Al Basrah AAS v1` is in the map rotation, then it will only appear once in the map rotation.
+2. Distinct map choices with the same map name (e.g. `Belaya RAAS v1` and `Belaya RAAS v2`) can be repeated in the map rotation but they must be far apart by a certain (adjustable) amount. For example, `Belaya RAAS v1` and `Belaya RAAS v2` may both appear in the same map rotation as long as they are not consecutive.
+3. All maps marked as bugged are not considered for the map rotation.
+
+## Installation
+Requires Python 3.6+ and `pip`. Install required dependencies using `pip3 install -r requirements.txt`.
+
+## Usage
+
+### Basic Usage
+To produce a random map rotation using the default options, run: `python3 squad_map_randomizer.py`
+This will generate a `MapRotation.cfg` file in the current working directory.
+
+### Discord Message
+In order to post the generated map rotation to Discord, follow these steps:
+1. Create a webhook for the Discord channel (you must be an admin of that channel).
+2. Provide the webhook URL using the `--discord-webhook-url` argument when running the script.
+e.g. `python3 squad_map_randomizer.py --discord-webhook-url https://discordapp.com/api/webhooks/...`
+
+### JSON layers file
+The script uses a JSON file as input containing all the map layer info in a simple format (lists of dictionaries).  See `https://github.com/bsubei/squad_map_layers` for the default JSON file used with this script.
+
+### Detailed Usage
+Run `python3 squad_map_randomizer.py --help` for detailed usage.
+
+## Automating with Crontab
+See the `crontab.example` for an example on what to add to the crontab to run this script automatically (Linux). For Windows, please use `schtasks` to schedule this script to run.
+
+## Running unit tests
 You can run the unit tests with `python3 -m pytest` in the project root directory (add `-s` to enable `ipdb` support).
 
-# License
+## License
 The license is GPLv3. See LICENSE file.

--- a/configs/default_config.yml
+++ b/configs/default_config.yml
@@ -1,8 +1,8 @@
-seeding:
+starting_maps:
   - gamemode: Skirmish
   - gamemode: Skirmish
-pattern_repeats: 5
-pattern:
+number_of_repeats: 5
+regular_maps:
   - gamemode:
     - AAS
     - RAAS

--- a/configs/example_config.yml
+++ b/configs/example_config.yml
@@ -1,0 +1,22 @@
+seeding:
+  - gamemode: Skirmish
+  - gamemode: Skirmish
+pattern_repeats: 5
+pattern:
+  - gamemode:
+    - AAS
+    - RAAS
+    map_size: small
+  - gamemode:
+    - AAS
+    - RAAS
+    map_size: medium
+  - gamemode:
+    - AAS
+    - RAAS
+    map_size: medium
+  - gamemode:
+    - AAS
+    - RAAS
+    map_size: large
+    helicopters: true

--- a/configs/examples/any_three_maps.yml
+++ b/configs/examples/any_three_maps.yml
@@ -1,0 +1,5 @@
+# Just three maps with no filters. Note "any" is a special keyword here.
+regular_maps:
+ - any
+ - any
+ - any

--- a/configs/examples/complex_example.yml
+++ b/configs/examples/complex_example.yml
@@ -1,0 +1,29 @@
+# Two starting maps, both Skirmish. One of them has GB or INS in either teams. The other is a Fool's Road map.
+starting_maps:
+  - gamemode: Skirmish
+    team:
+      - GB
+      - INS
+  - gamemode: Skirmish
+    map: Fool's Road
+
+# Repeat the regular maps 3 times.
+number_of_repeats: 3
+
+# Five maps (repeated 3 times).
+regular_maps:
+  # For the first map, the teams should have either INS or MIL.
+  - team:
+    - INS
+    - MIL
+  # For the second, the map size must be small and must have US in one of the teams.
+  - map_size: small
+    team: US
+  # For the third, the map size must be medium.
+  - map_size: medium
+  # For the fourth, it must be large and have helicopters.
+  - map_size: large
+    helicopters: true
+  # For the fifth, it must be large and must not have helicopters.
+  - map_size: large
+    helicopters: false

--- a/configs/examples/helicopters_every_other_map.yml
+++ b/configs/examples/helicopters_every_other_map.yml
@@ -1,0 +1,5 @@
+# Ten maps in total, where every other map either has helicopters or does not have helicopters.
+number_of_repeats: 5
+regular_maps:
+  - helicopters: true
+  - helicopters: false

--- a/configs/examples/murica_choppers_only.yml
+++ b/configs/examples/murica_choppers_only.yml
@@ -1,0 +1,5 @@
+# Five maps, all of them have US as one of the teams and helicopters.
+number_of_repeats: 5
+regular_maps:
+  - team: US
+    helicopters: true

--- a/configs/examples/two_seeding_then_any_ten_maps.yml
+++ b/configs/examples/two_seeding_then_any_ten_maps.yml
@@ -1,0 +1,7 @@
+# Two Skirmish maps for seeding, and then any ten maps. Note "any" is a special keyword here.
+starting_maps:
+  - gamemode: Skirmish
+  - gamemode: Skirmish
+number_of_repeats: 10
+regular_maps:
+  - any

--- a/squad_map_randomizer.py
+++ b/squad_map_randomizer.py
@@ -229,11 +229,18 @@ def send_rotation_to_discord(map_rotation, discord_webhook_url):
         webhook.execute()
 
 
+# TODO cleanup
 def validate_config(config, layers):
     """
     Raises InvalidConfigException if the given config is invalid. Uses the given layers to make sure the config is
     compatible.
     """
+    # Validate that the given layers is valid (we need to use its fields to ensure the config is valid).
+    if (not isinstance(layers, list) or
+            len(layers) < 1 or
+            not all(isinstance(layer, collections.Mapping) for layer in layers)):
+        raise InvalidConfigException('The given layers to check the config against is invalid!')
+
     # NOTE(bsubei): the only field in the config that is necessary is 'pattern', and it must be a list with at least one
     # element.
     pattern_config = config.get('pattern')

--- a/tests/test_squad_map_randomizer.py
+++ b/tests/test_squad_map_randomizer.py
@@ -1,0 +1,173 @@
+#! /usr/bin/env python3
+
+# Copyright (C) 2020 Basheer Subei
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# A testing class to test the squad_map_randomizer script.
+#
+
+import pytest
+from unittest import mock
+
+import squad_map_randomizer
+
+# Some constants used in mock objects.
+# TODO
+
+
+class TestSquadMapRandomizer:
+    """ Test class (uses pytest) for the SquadMapRandomizer script. """
+
+    MOCK_RCON_CLIENT = mock.MagicMock()
+
+    @pytest.fixture
+    def example_layers(self):
+        """ The fixture function to return an example list of layers containing all valid fields. """
+        return [{
+            "map": "Al Basrah",
+            "layer": "Al Basrah AAS v1",
+            "gamemode": "AAS",
+            "version": "v1",
+            "team1": "US",
+            "team2": "INS",
+            "helicopters": False,
+            "night": False,
+            "RAA_Lanes": False,
+            "Invasion_Random": False,
+            "bugged": False,
+            "map_size": "medium"
+        }]
+
+    @pytest.fixture
+    def example_config(self):
+        """ The fixture function to return an example config. """
+        return {
+                'seeding': [
+                        {'gamemode': 'Skirmish'},
+                        {'gamemode': 'Skirmish'}],
+                'pattern_repeats': 5,
+                'pattern': [
+                        {'gamemode': ['AAS', 'RAAS'], 'map_size': 'small'},
+                        {'gamemode': ['AAS', 'RAAS'], 'map_size': 'medium'},
+                        {'gamemode': ['AAS', 'RAAS'], 'map_size': 'medium'},
+                        {'gamemode': ['AAS', 'RAAS'], 'map_size': 'large', 'helicopters': True}
+                    ]
+                }
+
+    def test_is_config_valid(self, example_config, example_layers):
+        """ Tests that the example config successfully validates. """
+
+        # Valid config test cases:
+
+        # Test that a valid example config (which is also the default config) does not raise.
+        squad_map_randomizer.validate_config(example_config, example_layers)
+
+        # Test a valid config with the bare minimum information (just one map with no filters applied).
+        # NOTE(bsubei): a config without 'seeding' and 'pattern_repeats' is still valid (they have defaults).
+        squad_map_randomizer.validate_config({'pattern': ['any']}, example_layers)
+
+        # Test a valid config with the a seeding config.
+        squad_map_randomizer.validate_config({'pattern': ['any'], 'seeding': ['any']}, example_layers)
+
+        # Test a valid config with pattern_repeats as a large integer.
+        squad_map_randomizer.validate_config({'pattern': ['any'], 'pattern_repeats': 10000}, example_layers)
+
+        # Test that a config with map name is valid.
+        squad_map_randomizer.validate_config(
+            {'pattern': [
+                {'map': 'unimportant'},
+                {'map': ['multiple', 'possible', 'map names']},
+                {'map': 'not used really'},
+            ]}, example_layers)
+
+        # Test that the 'team' filter field is special and maps to either 'team1' or 'team2' names and is valid.
+        squad_map_randomizer.validate_config(
+            {'pattern': [
+                {'team': ['US', 'GB']},
+                {'map': 'unimportant'},
+                {'map': 'not used really'},
+            ]}, example_layers)
+
+        # Invalid config test cases:
+
+        # Test that a missing or incorrect 'pattern' field makes it invalid.
+        with pytest.raises(squad_map_randomizer.InvalidConfigException):
+            squad_map_randomizer.validate_config(
+                {
+                    'intentionally_wrong_field_name': [
+                        {'gamemode': ['AAS', 'RAAS'], 'map_size': 'small'}, ],
+                    'seeding': [
+                        {'gamemode': ['AAS', 'RAAS'], 'map_size': 'small'}, ],
+                }, example_layers)
+        with pytest.raises(squad_map_randomizer.InvalidConfigException):
+            squad_map_randomizer.validate_config(
+                {'pattern': 'supposed to be a list here'}, example_layers)
+        with pytest.raises(squad_map_randomizer.InvalidConfigException):
+            squad_map_randomizer.validate_config(
+                {'pattern': []}, example_layers)
+        with pytest.raises(squad_map_randomizer.InvalidConfigException):
+            squad_map_randomizer.validate_config(
+                {'pattern': ['blargh', 'random', 'stuff']}, example_layers)
+        with pytest.raises(squad_map_randomizer.InvalidConfigException):
+            squad_map_randomizer.validate_config(
+                {'pattern': [123, 456]}, example_layers)
+
+        # Test that an incorrect 'seeding' field makes it invalid.
+        with pytest.raises(squad_map_randomizer.InvalidConfigException):
+            squad_map_randomizer.validate_config(
+                {'seeding': 'blargh',
+                    'pattern': ['any']}, example_layers)
+        with pytest.raises(squad_map_randomizer.InvalidConfigException):
+            squad_map_randomizer.validate_config(
+                {'seeding': [],
+                    'pattern': ['any']}, example_layers)
+        with pytest.raises(squad_map_randomizer.InvalidConfigException):
+            squad_map_randomizer.validate_config(
+                {'seeding': ['blargh', 'does not exist'],
+                    'pattern': ['any']}, example_layers)
+        with pytest.raises(squad_map_randomizer.InvalidConfigException):
+            squad_map_randomizer.validate_config(
+                {'seeding': [42, 77, 0],
+                    'pattern': ['any']}, example_layers)
+
+        # Test that an incorrect 'pattern_repeats' field makes it invalid.
+        with pytest.raises(squad_map_randomizer.InvalidConfigException):
+            squad_map_randomizer.validate_config(
+                {'pattern': ['any'], 'pattern_repeats': 'supposed to be a number'}, example_layers)
+        with pytest.raises(squad_map_randomizer.InvalidConfigException):
+            squad_map_randomizer.validate_config(
+                {'pattern': ['any'], 'pattern_repeats': 0}, example_layers)
+        with pytest.raises(squad_map_randomizer.InvalidConfigException):
+            squad_map_randomizer.validate_config(
+                {'pattern': ['any'], 'pattern_repeats': -100}, example_layers)
+
+        # Test that a non-existing filter field name in 'seeding' is invalid.
+        with pytest.raises(squad_map_randomizer.InvalidConfigException):
+            squad_map_randomizer.validate_config(
+                {'seeding': [{'gamemode': 'blabla', 'THIS_DOES_NOT_EXIST': 'INVALID CONFIG HALP'}],
+                    'pattern': ['any']}, example_layers)
+
+        # Test that a config with a non-existing filter field name in 'pattern' is invalid.
+        with pytest.raises(squad_map_randomizer.InvalidConfigException):
+            squad_map_randomizer.validate_config(
+                {'pattern': [
+                    {'map': 'unimportant', 'THIS_DOES_NOT_EXIST': 'INVALID CONFIG'},
+                    {'map': ['multiple', 'possible', 'map names']},
+                    {'map': 'not used really'},
+                ]}, example_layers)
+
+    def test_parse_config(self, example_config, example_layers):
+        """ Tests that we can call parse_config correctly. """
+        # We expect the example config above to exactly match the one parsed from configs/example_config.yml.
+        EXAMPLE_CONFIG_PATH = 'configs/example_config.yml'
+        with mock.patch('squad_map_randomizer.validate_config'):
+            assert squad_map_randomizer.parse_config(EXAMPLE_CONFIG_PATH, example_layers) == example_config

--- a/tests/test_squad_map_randomizer.py
+++ b/tests/test_squad_map_randomizer.py
@@ -20,9 +20,6 @@ from unittest import mock
 
 import squad_map_randomizer
 
-# Some constants used in mock objects.
-# TODO
-
 
 class TestSquadMapRandomizer:
     """ Test class (uses pytest) for the SquadMapRandomizer script. """
@@ -31,7 +28,26 @@ class TestSquadMapRandomizer:
 
     @pytest.fixture
     def example_layers(self):
-        """ The fixture function to return an example list of layers containing all valid fields. """
+        """
+        The fixture function to return a list of layers containing all valid fields (uses the real layers stored in the
+        bsubei/squad_map_layers GitHub repository.
+        Below is an example of a single layer (so we get a list of these):
+        {
+            "map": "Al Basrah",
+            "layer": "Al Basrah AAS v1",
+            "gamemode": "AAS",
+            "version": "v1",
+            "team1": "US",
+            "team2": "INS",
+            "helicopters": False,
+            "night": False,
+            "RAA_Lanes": False,
+            "Invasion_Random": False,
+            "bugged": False,
+            "map_size": "medium",
+        }
+        """
+        # TODO pull this layers from the GitHub repo
         return [{
             "map": "Al Basrah",
             "layer": "Al Basrah AAS v1",
@@ -44,7 +60,7 @@ class TestSquadMapRandomizer:
             "RAA_Lanes": False,
             "Invasion_Random": False,
             "bugged": False,
-            "map_size": "medium"
+            "map_size": "medium",
         }]
 
     @pytest.fixture
@@ -98,6 +114,14 @@ class TestSquadMapRandomizer:
             ]}, example_layers)
 
         # Invalid config test cases:
+
+        # Test that an invalid layers also makes the config "invalid".
+        with pytest.raises(squad_map_randomizer.InvalidConfigException):
+            squad_map_randomizer.validate_config({'pattern': ['any']}, 'not a list')
+        with pytest.raises(squad_map_randomizer.InvalidConfigException):
+            squad_map_randomizer.validate_config({'pattern': ['any']}, [])
+        with pytest.raises(squad_map_randomizer.InvalidConfigException):
+            squad_map_randomizer.validate_config({'pattern': ['any']}, ['not all elements are dict', {'a': 1}])
 
         # Test that a missing or incorrect 'pattern' field makes it invalid.
         with pytest.raises(squad_map_randomizer.InvalidConfigException):

--- a/tests/test_squad_map_randomizer.py
+++ b/tests/test_squad_map_randomizer.py
@@ -15,10 +15,69 @@
 # A testing class to test the squad_map_randomizer script.
 #
 
+import os
 import pytest
+import random
 from unittest import mock
+import yaml
 
 import squad_map_randomizer
+
+# The path to the default config file. This should always match the default_config fixture.
+DEFAULT_CONFIG_PATH = 'configs/default_config.yml'
+
+
+# Below are helper predicates used in the filters.
+def is_skirmish(layer):
+    return layer['gamemode'] == 'Skirmish'
+
+
+def is_aas(layer):
+    return layer['gamemode'] == 'AAS'
+
+
+def is_raas(layer):
+    return layer['gamemode'] == 'RAAS'
+
+
+def is_small_map(layer):
+    return layer['map_size'] == 'small'
+
+
+def is_medium_map(layer):
+    return layer['map_size'] == 'medium'
+
+
+def is_large_map(layer):
+    return layer['map_size'] == 'large'
+
+
+def is_helicopters(layer):
+    return layer['helicopters']
+
+
+# Below are helpers used in tests for valid map rotations (checking for duplicates).
+def has_duplicate_layers(rotation):
+    """ Given a map rotation (list of layers), return True if any of the layers are duplicates and False otherwise. """
+    return len(set([layer['layer'] for layer in rotation])) < len(rotation)
+
+
+def has_close_duplicate_maps(rotation, min_distance_duplicate):
+    """
+    Given a map rotation (list of layers), return True if any layers with the same map name are min_distance_duplicate
+    close to each other. Return False otherwise.
+    """
+    # Check for duplicate map names that are too close together.
+    for current_idx, current_layer in enumerate(rotation):
+        # Get the distances from the current layer to the other layers with the same map name (only checking layers
+        # after the current layer).
+        distances = [i + 1 for i, other in enumerate(rotation[current_idx + 1:])
+                     if current_layer['map'] == other['map']]
+        # Make sure no duplicates are too close. If any are too close, return True.
+        if any(distance <= min_distance_duplicate for distance in distances):
+            return True
+    # Return False since we did not find any duplicates that were too close.
+    return False
 
 
 class TestSquadMapRandomizer:
@@ -26,8 +85,8 @@ class TestSquadMapRandomizer:
 
     MOCK_RCON_CLIENT = mock.MagicMock()
 
-    @pytest.fixture
-    def example_layers(self):
+    @pytest.fixture(scope='module')
+    def default_layers(self):
         """
         The fixture function to return a list of layers containing all valid fields (uses the real layers stored in the
         bsubei/squad_map_layers GitHub repository.
@@ -47,151 +106,289 @@ class TestSquadMapRandomizer:
             "map_size": "medium",
         }
         """
-        # TODO pull this layers from the GitHub repo
-        return [{
-            "map": "Al Basrah",
-            "layer": "Al Basrah AAS v1",
-            "gamemode": "AAS",
-            "version": "v1",
-            "team1": "US",
-            "team2": "INS",
-            "helicopters": False,
-            "night": False,
-            "RAA_Lanes": False,
-            "Invasion_Random": False,
-            "bugged": False,
-            "map_size": "medium",
-        }]
+        return squad_map_randomizer.get_json_layers(None, squad_map_randomizer.DEFAULT_LAYERS_URL)
 
     @pytest.fixture
-    def example_config(self):
-        """ The fixture function to return an example config. """
+    def default_config(self):
+        """ The fixture function to return the default config. """
         return {
-                'seeding': [
-                        {'gamemode': 'Skirmish'},
-                        {'gamemode': 'Skirmish'}],
-                'pattern_repeats': 5,
-                'pattern': [
-                        {'gamemode': ['AAS', 'RAAS'], 'map_size': 'small'},
-                        {'gamemode': ['AAS', 'RAAS'], 'map_size': 'medium'},
-                        {'gamemode': ['AAS', 'RAAS'], 'map_size': 'medium'},
-                        {'gamemode': ['AAS', 'RAAS'], 'map_size': 'large', 'helicopters': True}
-                    ]
-                }
+            'starting_maps': [
+                {'gamemode': 'Skirmish'},
+                {'gamemode': 'Skirmish'}],
+            'number_of_repeats': 5,
+            'regular_maps': [
+                {'gamemode': ['AAS', 'RAAS'], 'map_size': 'small'},
+                {'gamemode': ['AAS', 'RAAS'], 'map_size': 'medium'},
+                {'gamemode': ['AAS', 'RAAS'], 'map_size': 'medium'},
+                {'gamemode': ['AAS', 'RAAS'],
+                 'map_size': 'large', 'helicopters': True}
+            ]
+        }
 
-    def test_is_config_valid(self, example_config, example_layers):
-        """ Tests that the example config successfully validates. """
+    # Run this test 100 times with a different random seed each time.
+    @pytest.mark.parametrize('execution_number', range(100))
+    def test_get_map_rotation_default(self, default_config, default_layers, execution_number):
+        """ Tests that we can call get_map_rotation correctly on the default layers and config. """
+        # Set the random seed so the results are deterministic across different pytest invocations so we can reproduce
+        # test failures.
+        random.seed(execution_number)
+
+        # The default config will return 2 skirmish maps and 20 (R)AAS maps.
+        rotation = squad_map_randomizer.get_map_rotation(
+            default_config, default_layers)
+
+        # Expect the correct number of maps (for each type as well).
+        assert len(rotation) == 22
+        num_skirmish_layers = sum([is_skirmish(layer) for layer in rotation])
+        num_AAS_layers = sum([is_aas(layer) for layer in rotation])
+        num_RAAS_layers = sum([is_raas(layer) for layer in rotation])
+        num_AAS_or_RAAS_layers = sum(
+            [is_aas(layer) or is_raas(layer) for layer in rotation])
+        assert num_skirmish_layers == 2
+        assert num_AAS_or_RAAS_layers == 20
+        assert num_AAS_layers + num_RAAS_layers == num_AAS_or_RAAS_layers
+
+        # Expect the correct number of repeated maps: 5 small AAS or RAAS maps, 10 medium AAS or RAAS maps, and 5 large
+        # AAS or RAAS maps with helicopters.
+        # NOTE(bsubei): you can see the "OR" relationship within a field ('gamemode') and the "AND" relationship across
+        # different fields ('gamemode', 'map_size', and 'helicopters').
+        assert sum([(is_aas(layer) or is_raas(layer))
+                    and is_small_map(layer) for layer in rotation]) == 5
+        assert sum([(is_aas(layer) or is_raas(layer))
+                    and is_medium_map(layer) for layer in rotation]) == 10
+        assert sum([
+            (is_aas(layer) or is_raas(layer)) and
+            is_large_map(layer) and
+            is_helicopters(layer) for layer in rotation]) == 5
+
+    # Run this test 100 times with a different random seed each time.
+    @pytest.mark.parametrize('execution_number', range(100))
+    def test_get_map_rotation_duplicates(self, default_layers, execution_number):
+        """
+        Tests that we can call get_map_rotation correctly and not get duplicate maps too close to each other or
+        duplicate layers at all.
+        """
+        # Set the random seed so the results are deterministic across different pytest invocations so we can reproduce
+        # test failures.
+        random.seed(execution_number)
+
+        # Use a config where the rotation could have a lot of duplicate maps.
+        config_with_potential_duplicates = {
+            'number_of_repeats': 5,
+            'regular_maps': [
+                {'map': 'Al Basrah'},
+                {'map': 'Belaya'},
+                {'map': 'Chora'},
+                {'map': 'Fool\'s Road'}]}
+
+        rotation = squad_map_randomizer.get_map_rotation(
+            config_with_potential_duplicates, default_layers)
+
+        # Check that no two layers with the same map name are too close.
+        assert not has_close_duplicate_maps(
+            rotation, squad_map_randomizer.NUM_MIN_LAYERS_BEFORE_DUPLICATE_MAP)
+        # Check that no two layers are duplicates.
+        assert not has_duplicate_layers(rotation)
+
+        # Test that if we intentionally make it impossible to avoid duplicates, it prints an error but continues.
+        impossible_config = {'number_of_repeats': 10,
+                             'regular_maps': [{'map': 'Chora'}]}
+        with mock.patch('squad_map_randomizer.logging.error') as mock_error:
+            rotation = squad_map_randomizer.get_map_rotation(
+                impossible_config, default_layers)
+            assert mock_error.call_count == 9
+            assert all('Could not get a valid map without duplicates!' in args[0][0]
+                       for args in mock_error.call_args_list)
+
+        # It will have some duplicate map names that are too close, but never duplicate layers (sampling without
+        # replacement).
+        assert has_close_duplicate_maps(
+            rotation, squad_map_randomizer.NUM_MIN_LAYERS_BEFORE_DUPLICATE_MAP)
+        assert not has_duplicate_layers(rotation)
+
+    def test_get_map_rotation_any(self, default_layers):
+        """ Tests that we can call get_map_rotation correctly with a config with the 'any' keyword. """
+        # Test case with a config containing the special 'any' keyword (signifying no filters for this layer).
+        config_with_any = {'regular_maps':
+                           ['any', {'gamemode': ['AAS', 'RAAS'], 'map_size': 'large', 'helicopters': True}, 'any']}
+        rotation = squad_map_randomizer.get_map_rotation(
+            config_with_any, default_layers)
+        # Check that the rotation has three layers, the second of which has filters while the rest have no filters.
+        assert len(rotation) == 3
+        assert ((is_aas(rotation[1]) or is_raas(rotation[1])) and
+                is_large_map(rotation[1]) and
+                is_helicopters(rotation[1]))
+
+    def test_get_map_rotation_team(self, default_layers):
+        """ Tests that we can call get_map_rotation correctly with a config with the 'team' filter. """
+        # Test that the 'team' filter is special and is accepted as a filter.
+        config_with_team = {'number_of_repeats': 5, 'regular_maps': [
+            {'team': ['INS', 'RU']},
+            {'team': ['US']}]}
+        rotation = squad_map_randomizer.get_map_rotation(
+            config_with_team, default_layers)
+
+        # Check that every other map starting from the first has either INS or RU in either team.
+        for layer in rotation[::2]:
+            assert 'INS' in [layer['team1'], layer['team2']
+                             ] or 'RU' in [layer['team1'], layer['team2']]
+        # Check that every other map starting from the second has US in either team.
+        for layer in rotation[1::2]:
+            assert 'US' in [layer['team1'], layer['team2']]
+
+    def test_get_map_rotation_examples(self, default_layers):
+        """ Tests that we can call get_map_rotation correctly on all the example configs. """
+        # Test that all example configs can be parsed without problems, and result in non-empty rotations.
+        for path in os.scandir('configs/examples/'):
+            config = squad_map_randomizer.parse_config(path, default_layers)
+            rotation = squad_map_randomizer.get_map_rotation(
+                config, default_layers)
+            assert len(rotation) > 0
+
+    def test_get_map_rotation_invalid_filter(self, default_layers):
+        """ Tests that we expect errors when get_map_rotation is called on config filters. """
+        # Test that incorrect filters (no layers meet the conditions) prints an error but continues.
+        config_with_team = {'number_of_repeats': 5, 'regular_maps': [
+            {'team': ['misspelled_name']},
+            {'team': ['US']}]}
+        with mock.patch('squad_map_randomizer.logging.error') as mock_error:
+            rotation = squad_map_randomizer.get_map_rotation(
+                config_with_team, default_layers)
+            # Check that only 5 errors are printed.
+            assert mock_error.call_count == 5
+            assert all('No maps to choose from after applying filter' in args[0][0]
+                       for args in mock_error.call_args_list)
+            # The other filter works correctly so we end up with 5 maps in the rotation.
+            assert len(rotation) == 5
+            assert all(layer['team1'] == 'US' or layer['team2']
+                       == 'US' for layer in rotation)
+
+    def test_is_config_valid_examples(self, default_layers):
+        """ Tests that all the example configs successfully validate. """
+        # Test that all example configs validate successfully.
+        for path in os.scandir('configs/examples/'):
+            with open(path, 'r') as f:
+                squad_map_randomizer.validate_config(
+                    yaml.load(f), default_layers)
+
+    def test_is_config_valid(self, default_config, default_layers):
+        """ Tests that all sorts of configs successfully validate. """
 
         # Valid config test cases:
 
-        # Test that a valid example config (which is also the default config) does not raise.
-        squad_map_randomizer.validate_config(example_config, example_layers)
+        # Test that a valid default config (which is also the default config) does not raise.
+        squad_map_randomizer.validate_config(default_config, default_layers)
 
         # Test a valid config with the bare minimum information (just one map with no filters applied).
-        # NOTE(bsubei): a config without 'seeding' and 'pattern_repeats' is still valid (they have defaults).
-        squad_map_randomizer.validate_config({'pattern': ['any']}, example_layers)
+        # NOTE(bsubei): a config without 'starting_maps' and 'number_of_repeats' is still valid (they have defaults).
+        squad_map_randomizer.validate_config(
+            {'regular_maps': ['any']}, default_layers)
 
-        # Test a valid config with the a seeding config.
-        squad_map_randomizer.validate_config({'pattern': ['any'], 'seeding': ['any']}, example_layers)
+        # Test a valid config with the a starting_maps config.
+        squad_map_randomizer.validate_config(
+            {'regular_maps': ['any'], 'starting_maps': ['any']}, default_layers)
 
-        # Test a valid config with pattern_repeats as a large integer.
-        squad_map_randomizer.validate_config({'pattern': ['any'], 'pattern_repeats': 10000}, example_layers)
+        # Test a valid config with number_of_repeats as a large integer.
+        squad_map_randomizer.validate_config(
+            {'regular_maps': ['any'], 'number_of_repeats': 10000}, default_layers)
 
         # Test that a config with map name is valid.
         squad_map_randomizer.validate_config(
-            {'pattern': [
+            {'regular_maps': [
                 {'map': 'unimportant'},
                 {'map': ['multiple', 'possible', 'map names']},
                 {'map': 'not used really'},
-            ]}, example_layers)
+            ]}, default_layers)
 
         # Test that the 'team' filter field is special and maps to either 'team1' or 'team2' names and is valid.
         squad_map_randomizer.validate_config(
-            {'pattern': [
+            {'regular_maps': [
                 {'team': ['US', 'GB']},
                 {'map': 'unimportant'},
                 {'map': 'not used really'},
-            ]}, example_layers)
+            ]}, default_layers)
 
         # Invalid config test cases:
 
         # Test that an invalid layers also makes the config "invalid".
         with pytest.raises(squad_map_randomizer.InvalidConfigException):
-            squad_map_randomizer.validate_config({'pattern': ['any']}, 'not a list')
+            squad_map_randomizer.validate_config(
+                {'regular_maps': ['any']}, 'not a list')
         with pytest.raises(squad_map_randomizer.InvalidConfigException):
-            squad_map_randomizer.validate_config({'pattern': ['any']}, [])
+            squad_map_randomizer.validate_config({'regular_maps': ['any']}, [])
         with pytest.raises(squad_map_randomizer.InvalidConfigException):
-            squad_map_randomizer.validate_config({'pattern': ['any']}, ['not all elements are dict', {'a': 1}])
+            squad_map_randomizer.validate_config({'regular_maps': ['any']}, [
+                                                 'not all elements are dict', {'a': 1}])
 
-        # Test that a missing or incorrect 'pattern' field makes it invalid.
+        # Test that a missing or incorrect 'regular_maps' field makes it invalid.
         with pytest.raises(squad_map_randomizer.InvalidConfigException):
             squad_map_randomizer.validate_config(
                 {
                     'intentionally_wrong_field_name': [
                         {'gamemode': ['AAS', 'RAAS'], 'map_size': 'small'}, ],
-                    'seeding': [
+                    'starting_maps': [
                         {'gamemode': ['AAS', 'RAAS'], 'map_size': 'small'}, ],
-                }, example_layers)
+                }, default_layers)
         with pytest.raises(squad_map_randomizer.InvalidConfigException):
             squad_map_randomizer.validate_config(
-                {'pattern': 'supposed to be a list here'}, example_layers)
+                {'regular_maps': 'supposed to be a list here'}, default_layers)
         with pytest.raises(squad_map_randomizer.InvalidConfigException):
             squad_map_randomizer.validate_config(
-                {'pattern': []}, example_layers)
+                {'regular_maps': []}, default_layers)
         with pytest.raises(squad_map_randomizer.InvalidConfigException):
             squad_map_randomizer.validate_config(
-                {'pattern': ['blargh', 'random', 'stuff']}, example_layers)
+                {'regular_maps': ['blargh', 'random', 'stuff']}, default_layers)
         with pytest.raises(squad_map_randomizer.InvalidConfigException):
             squad_map_randomizer.validate_config(
-                {'pattern': [123, 456]}, example_layers)
+                {'regular_maps': [123, 456]}, default_layers)
 
-        # Test that an incorrect 'seeding' field makes it invalid.
+        # Test that an incorrect 'starting_maps' field makes it invalid.
         with pytest.raises(squad_map_randomizer.InvalidConfigException):
             squad_map_randomizer.validate_config(
-                {'seeding': 'blargh',
-                    'pattern': ['any']}, example_layers)
+                {'starting_maps': 'blargh',
+                    'regular_maps': ['any']}, default_layers)
         with pytest.raises(squad_map_randomizer.InvalidConfigException):
             squad_map_randomizer.validate_config(
-                {'seeding': [],
-                    'pattern': ['any']}, example_layers)
+                {'starting_maps': [],
+                    'regular_maps': ['any']}, default_layers)
         with pytest.raises(squad_map_randomizer.InvalidConfigException):
             squad_map_randomizer.validate_config(
-                {'seeding': ['blargh', 'does not exist'],
-                    'pattern': ['any']}, example_layers)
+                {'starting_maps': ['blargh', 'does not exist'],
+                    'regular_maps': ['any']}, default_layers)
         with pytest.raises(squad_map_randomizer.InvalidConfigException):
             squad_map_randomizer.validate_config(
-                {'seeding': [42, 77, 0],
-                    'pattern': ['any']}, example_layers)
+                {'starting_maps': [42, 77, 0],
+                    'regular_maps': ['any']}, default_layers)
 
-        # Test that an incorrect 'pattern_repeats' field makes it invalid.
+        # Test that an incorrect 'number_of_repeats' field makes it invalid.
         with pytest.raises(squad_map_randomizer.InvalidConfigException):
             squad_map_randomizer.validate_config(
-                {'pattern': ['any'], 'pattern_repeats': 'supposed to be a number'}, example_layers)
+                {'regular_maps': ['any'], 'number_of_repeats': 'supposed to be a number'}, default_layers)
         with pytest.raises(squad_map_randomizer.InvalidConfigException):
             squad_map_randomizer.validate_config(
-                {'pattern': ['any'], 'pattern_repeats': 0}, example_layers)
+                {'regular_maps': ['any'], 'number_of_repeats': 0}, default_layers)
         with pytest.raises(squad_map_randomizer.InvalidConfigException):
             squad_map_randomizer.validate_config(
-                {'pattern': ['any'], 'pattern_repeats': -100}, example_layers)
+                {'regular_maps': ['any'], 'number_of_repeats': -100}, default_layers)
 
-        # Test that a non-existing filter field name in 'seeding' is invalid.
+        # Test that a non-existing filter field name in 'starting_maps' is invalid.
         with pytest.raises(squad_map_randomizer.InvalidConfigException):
             squad_map_randomizer.validate_config(
-                {'seeding': [{'gamemode': 'blabla', 'THIS_DOES_NOT_EXIST': 'INVALID CONFIG HALP'}],
-                    'pattern': ['any']}, example_layers)
+                {'starting_maps': [{'gamemode': 'blabla', 'THIS_DOES_NOT_EXIST': 'INVALID CONFIG HALP'}],
+                    'regular_maps': ['any']}, default_layers)
 
-        # Test that a config with a non-existing filter field name in 'pattern' is invalid.
+        # Test that a config with a non-existing filter field name in 'regular_maps' is invalid.
         with pytest.raises(squad_map_randomizer.InvalidConfigException):
             squad_map_randomizer.validate_config(
-                {'pattern': [
+                {'regular_maps': [
                     {'map': 'unimportant', 'THIS_DOES_NOT_EXIST': 'INVALID CONFIG'},
                     {'map': ['multiple', 'possible', 'map names']},
                     {'map': 'not used really'},
-                ]}, example_layers)
+                ]}, default_layers)
 
-    def test_parse_config(self, example_config, example_layers):
+    def test_parse_config(self, default_config, default_layers):
         """ Tests that we can call parse_config correctly. """
-        # We expect the example config above to exactly match the one parsed from configs/example_config.yml.
-        EXAMPLE_CONFIG_PATH = 'configs/example_config.yml'
+        # We expect the default config above to exactly match the one parsed from configs/default_config.yml.
         with mock.patch('squad_map_randomizer.validate_config'):
-            assert squad_map_randomizer.parse_config(EXAMPLE_CONFIG_PATH, example_layers) == example_config
+            assert squad_map_randomizer.parse_config(
+                DEFAULT_CONFIG_PATH, default_layers) == default_config


### PR DESCRIPTION
fixes #1, now parses a config and uses that to filter when creating a map rotation.

Manually ran the script with the example config files and manually validated that the produced rotations are correct.

New unit tests pass.